### PR TITLE
Project-specific unit config files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- unit config files are searched relative to working directory
 
 ## [0.3.2] - 2024-05-23
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -90,8 +90,9 @@ data:
 ## Unit files
 Unit files are used to determine the units of datasets, particularly for datasets that do not have metadata
 that can be used to infer units. Unit files are specified either explicitly via the `unitfile` option in `scida.load`
-or implicitly via the simulation configuration, see above. Relative paths, such as `units/simnameunits.yaml` are
-relative to the user/package simulation config folder. The former (`~/.config/scida/`) takes precedence.
+or implicitly via the simulation configuration, see above. The precedence in descending order is: absolute paths,
+relative paths in the current working directory, relative paths in the user config folder (`~/.config/scida/`), and
+the package config folder.
 
 A unit file could look like this:
 

--- a/src/scida/config.py
+++ b/src/scida/config.py
@@ -219,14 +219,19 @@ def get_config_fromfile(resource: str) -> Dict:
             conf = yaml.safe_load(file)
         return conf
     # 2. non-absolute path?
-    # 2.1. check ~/.config/scida/
+    # 2.1. check local (project-specific) path
+    if os.path.isfile(resource):
+        with open(resource, "r") as file:
+            conf = yaml.safe_load(file)
+        return conf
+    # 2.2. check ~/.config/scida/
     bpath = os.path.expanduser("~/.config/scida")
     path = os.path.join(bpath, resource)
     if os.path.isfile(path):
         with open(path, "r") as file:
             conf = yaml.safe_load(file)
         return conf
-    # 2.2 check scida package resources
+    # 2.3. check scida package resources
     resource_path = "scida.configfiles"
     resource_elements = resource.split("/")
     rname = resource_elements[-1]


### PR DESCRIPTION
Config files for units could previously be located with absolute paths, in the user config path or the package config path. When working on a project that, e.g., does not rely on downloaded simulation snapshots but when using snapshots from an own simulation, quantities might be very project-specific. When the unit description is maintained outside the project repository, the synchronization between computers requires two steps.

With this change, a project-specific unit configuration can be maintained. This is portable because it does not rely on absolute paths that previously was the only way to setup a local unit configuration.