### PR TITLE
Fix unbound particle masking in haloquantity lookup

### DIFF
--- a/src/scida/customs/arepo/dataset.py
+++ b/src/scida/customs/arepo/dataset.py
@@ -169,8 +169,14 @@ class ArepoSnapshot(SpatialCartesian3DMixin, GadgetStyleSnapshot):
             ureg = self.ureg
 
         # non-virtual catalog fields for better performance
-        nonvirtual_datasets = ["Group/GroupFirstSub", "Group/GroupLenType", "Group/GroupNsubs",
-                               "Subhalo/SubhaloGrNr", "Subhalo/SubhaloGroupNr", "Subhalo/SubhaloLenType"]
+        nonvirtual_datasets = [
+            "Group/GroupFirstSub",
+            "Group/GroupLenType",
+            "Group/GroupNsubs",
+            "Subhalo/SubhaloGrNr",
+            "Subhalo/SubhaloGroupNr",
+            "Subhalo/SubhaloLenType",
+        ]
 
         self.catalog = cls(
             self.catalog,
@@ -1110,10 +1116,12 @@ def get_hidx_daskwrap(gidx, halocelloffsets, index_unbound=None):
     )
 
 
-def get_haloquantity_daskwrap(gidx, halocelloffsets, valarr):
-    hidx = get_hidx_daskwrap(gidx, halocelloffsets)
+def get_haloquantity_daskwrap(
+    gidx, halocelloffsets, valarr, index_unbound=9223372036854775807
+):
+    hidx = get_hidx_daskwrap(gidx, halocelloffsets, index_unbound=index_unbound)
     dmax = np.iinfo(hidx.dtype).max
-    mask = ~((hidx == -1) | (hidx == dmax))
+    mask = ~((hidx == index_unbound) | (hidx == dmax))
     result = -1.0 * np.ones(hidx.shape, dtype=valarr.dtype)
     result[mask] = valarr[hidx[mask]]
     return result
@@ -1135,13 +1143,18 @@ def compute_haloquantity(gidx, halocelloffsets, hvals, *args):
     units = None
     if hasattr(hvals, "units"):
         units = hvals.units
+        hvals = hvals.magnitude
+    kw = dict()
+    if len(hvals.shape) == 2:
+        kw = dict(drop_axis=0, new_axis=0)
     res = map_blocks(
         get_haloquantity_daskwrap,
         gidx,
         halocelloffsets,
         hvals,
-        meta=np.array((), dtype=hvals.dtype),
+        dtype=hvals.dtype,
         output_units=units,
+        **kw,
     )
     return res
 


### PR DESCRIPTION
## Summary
- Fix incorrect unbound particle check in `get_haloquantity_daskwrap` (was comparing against `-1` instead of `index_unbound`)
- Thread `index_unbound` parameter through to the dask wrapper
- Add support for 2D halo quantities (e.g. positions/velocities)

## Test plan
- [ ] Verify haloquantity lookup for datasets with unbound particles
- [ ] Test with 2D halo quantities (positions, velocities)

🤖 Generated with [Claude Code](https://claude.com/claude-code)