### PR TITLE
Make regression-tests workflow data check non-fatal

### DIFF
--- a/.github/workflows/regression-tests.yml
+++ b/.github/workflows/regression-tests.yml
@@ -61,9 +61,13 @@ jobs:
           echo "SCIDA_TESTDATA_PATH=$SCIDA_TESTDATA_PATH"
           find "$SCIDA_TESTDATA_PATH" -maxdepth 2 -mindepth 1 | sort | head -100
 
-          # Report which testdata.yaml entries are missing on the runner. Not fatal:
-          # tests using missing entries are skipped via SCIDA_TESTDATA_SILENT_UNAVAILABLE=FALSE
-          # + pytest -rs, so absences surface as visible skips in the report.
+          # Report which testdata.yaml entries are missing on the runner. Individual
+          # gaps are not fatal — tests using missing entries are skipped via
+          # SCIDA_TESTDATA_SILENT_UNAVAILABLE=FALSE + pytest -rs, so absences surface
+          # as visible skips in the report. But fail if a majority of entries are
+          # missing, which usually indicates a broken/unmounted volume rather than
+          # legitimately absent data; pytest returns 0 for all-skipped runs and would
+          # otherwise hide the breakage as a green job.
           uv run python - <<'PY'
           import os
           from pathlib import Path
@@ -83,6 +87,12 @@ jobs:
           if missing:
               print(f"Missing {len(missing)}/{len(entries)} regression test data entries (tests will be skipped):")
               print("\n".join(missing))
+              if 2 * len(missing) > len(entries):
+                  raise SystemExit(
+                      f"More than half of regression test data entries are missing "
+                      f"({len(missing)}/{len(entries)}); aborting to surface what is "
+                      "likely a broken mount."
+                  )
           else:
               print(f"All {len(entries)} regression test data entries present.")
           PY

--- a/.github/workflows/regression-tests.yml
+++ b/.github/workflows/regression-tests.yml
@@ -61,6 +61,9 @@ jobs:
           echo "SCIDA_TESTDATA_PATH=$SCIDA_TESTDATA_PATH"
           find "$SCIDA_TESTDATA_PATH" -maxdepth 2 -mindepth 1 | sort | head -100
 
+          # Report which testdata.yaml entries are missing on the runner. Not fatal:
+          # tests using missing entries are skipped via SCIDA_TESTDATA_SILENT_UNAVAILABLE=FALSE
+          # + pytest -rs, so absences surface as visible skips in the report.
           uv run python - <<'PY'
           import os
           from pathlib import Path
@@ -78,9 +81,10 @@ jobs:
                   missing.append(str(path))
 
           if missing:
-              print("Missing regression test data entries:")
+              print(f"Missing {len(missing)}/{len(entries)} regression test data entries (tests will be skipped):")
               print("\n".join(missing))
-              raise SystemExit(1)
+          else:
+              print(f"All {len(entries)} regression test data entries present.")
           PY
 
       - name: Run regression tests


### PR DESCRIPTION
## Summary
Follow-up to #235. The pre-run check in `.github/workflows/regression-tests.yml` required every entry in `tests/testdata.yaml` to be present on the self-hosted runner and failed the job on any missing entry, which caused the first scheduled run to fail before pytest ever started.

Missing testdata is already handled at the test level by the `require_testdata*` decorators in `tests/testdata_properties.py`. With `SCIDA_TESTDATA_SILENT_UNAVAILABLE=FALSE` and `pytest -rs`, absences surface as visible skips in the report.

This PR keeps the check as **diagnostic output** (which entries are missing, with a count) but no longer fails the job.

## Test plan
- [ ] Trigger via `workflow_dispatch` and confirm the job proceeds past the data-check step when entries from `tests/testdata.yaml` are absent
- [ ] Confirm the step still prints the missing entries for visibility
- [ ] Confirm `pytest -rs` summary lists the skipped tests with reasons

🤖 Generated with [Claude Code](https://claude.com/claude-code)