### PR TITLE
[codex] Refine dataset type detection confidence

### DIFF
--- a/src/scida/customs/arepo/series.py
+++ b/src/scida/customs/arepo/series.py
@@ -11,12 +11,19 @@ from os.path import join
 import h5py
 
 from scida.customs.gadgetstyle.series import GadgetStyleSimulation
-from scida.discovertypes import CandidateStatus
+from scida.discovertypes import (
+    CandidateStatus,
+    Confidence,
+    DetectionResult,
+    Specificity,
+)
 from scida.misc import group_by_common_prefix
 
 
 class ArepoSimulation(GadgetStyleSimulation):
     """A series representing an Arepo simulation."""
+
+    _detection_specificity = Specificity.FAMILY
 
     def __init__(self, path, lazy=True, async_caching=False, **interface_kwargs):
         """
@@ -97,5 +104,9 @@ class ArepoSimulation(GadgetStyleSimulation):
                     if "Header" in f:
                         if "NumFilesPerSnapshot" in f["Header"].attrs:
                             if f["Header"].attrs["NumFilesPerSnapshot"] == 1:
-                                valid = CandidateStatus.YES
+                                valid = DetectionResult.match(
+                                    Confidence.GENERIC_HEADER,
+                                    specificity=cls._detection_specificity,
+                                    evidence=("NumFilesPerSnapshot=1",),
+                                )
         return valid

--- a/src/scida/customs/swift/dataset.py
+++ b/src/scida/customs/swift/dataset.py
@@ -7,12 +7,19 @@ from __future__ import annotations
 import os
 
 from scida import GadgetStyleSnapshot
-from scida.discovertypes import CandidateStatus
+from scida.discovertypes import (
+    CandidateStatus,
+    Confidence,
+    DetectionResult,
+    Specificity,
+)
 from scida.io import load_metadata
 
 
 class SwiftSnapshot(GadgetStyleSnapshot):
     """SWIFT snapshot dataset."""
+
+    _detection_specificity = Specificity.FAMILY
 
     def __init__(self, path, chunksize="auto", virtualcache=True, **kwargs) -> None:
         """
@@ -51,4 +58,8 @@ class SwiftSnapshot(GadgetStyleSnapshot):
         comparestr = metadata_raw.get("/Code", {}).get("Code", b"").decode()
         if "SWIFT" not in comparestr:
             return CandidateStatus.NO
-        return CandidateStatus.MAYBE
+        return DetectionResult.match(
+            Confidence.FORMAT_MARKER,
+            specificity=cls._detection_specificity,
+            evidence=("Code=SWIFT",),
+        )

--- a/src/scida/customs/swift/series.py
+++ b/src/scida/customs/swift/series.py
@@ -7,13 +7,20 @@ from __future__ import annotations
 import pathlib
 
 from scida.customs.gadgetstyle.series import GadgetStyleSimulation
-from scida.discovertypes import CandidateStatus
+from scida.discovertypes import (
+    CandidateStatus,
+    Confidence,
+    DetectionResult,
+    Specificity,
+)
 
 
 class SwiftSimulation(GadgetStyleSimulation):
     """
     A dataseries representing a SWIFT simulation.
     """
+
+    _detection_specificity = Specificity.FAMILY
 
     def __init__(self, path, lazy=True, async_caching=False, **interface_kwargs):
         """
@@ -52,6 +59,10 @@ class SwiftSimulation(GadgetStyleSimulation):
             return CandidateStatus.NO
         pcode = p / "Code" / "swiftsim"
         if pcode.exists():
-            return CandidateStatus.YES
+            return DetectionResult.match(
+                Confidence.FORMAT_MARKER,
+                specificity=cls._detection_specificity,
+                evidence=("Code/swiftsim",),
+            )
         # TODO: check individual snapshot for swift header
         return CandidateStatus.NO

--- a/src/scida/discovertypes.py
+++ b/src/scida/discovertypes.py
@@ -7,7 +7,8 @@ from __future__ import annotations
 import logging
 import os
 from collections import Counter
-from enum import Enum
+from dataclasses import dataclass
+from enum import Enum, IntEnum
 from functools import reduce
 from inspect import getmro
 
@@ -25,15 +26,15 @@ log = logging.getLogger(__name__)
 
 def is_valid_candidate(val):
     """
-    Map mix of old bool and new Candidate Status enum to bool.
+    Map legacy bools to candidate status while passing through rich results.
     Parameters
     ----------
-    val: bool or CandidateStatus
+    val: bool, CandidateStatus, or DetectionResult
         Value to map.
 
     Returns
     -------
-    CandidateStatus
+    CandidateStatus or DetectionResult
     """
     if isinstance(val, bool):
         if val:
@@ -53,6 +54,105 @@ class CandidateStatus(Enum):
     NO = 0  # definitely not a candidate
     MAYBE = 1  # not sure yet
     YES = 2  # yes, this is a candidate
+
+
+class Confidence(IntEnum):
+    """
+    Quality of the evidence for a detection candidate.
+    """
+
+    NO = 0
+    PATH_SHAPE = 10
+    GENERIC_HEADER = 30
+    FORMAT_MARKER = 60
+    UNIQUE_MARKER = 80
+    EXPLICIT = 100
+
+
+class Specificity(IntEnum):
+    """
+    Narrowness of the class being claimed.
+    """
+
+    BASE = 0
+    GENERIC = 10
+    FAMILY = 20
+    SUBFAMILY = 30
+    INSTANCE = 40
+
+
+@dataclass(frozen=True)
+class DetectionResult:
+    """
+    Rich detection result separating evidence quality from class specificity.
+    """
+
+    confidence: Confidence
+    specificity: Specificity | int | None = None
+    evidence: tuple[str, ...] = ()
+
+    @classmethod
+    def no(cls, *evidence: str):
+        return cls(Confidence.NO, evidence=evidence)
+
+    @classmethod
+    def match(
+        cls,
+        confidence: Confidence,
+        *,
+        specificity: Specificity | int | None = None,
+        evidence: tuple[str, ...] | list[str] = (),
+    ):
+        return cls(confidence, specificity=specificity, evidence=tuple(evidence))
+
+    @property
+    def compatible(self) -> bool:
+        return self.confidence != Confidence.NO
+
+
+def _class_specificity(cls) -> int:
+    specificity = getattr(cls, "_detection_specificity", None)
+    if specificity is not None:
+        return (
+            specificity.value if isinstance(specificity, Specificity) else specificity
+        )
+    mro = getmro(cls)
+    return 10 * len(
+        [
+            c
+            for c in mro
+            if c is not object
+            and "Mixin" not in c.__name__
+            and c.__name__ not in {"Dataset", "BaseDataset", "DatasetSeries"}
+        ]
+    )
+
+
+def _candidate_to_detection_result(val, cls) -> DetectionResult:
+    val = is_valid_candidate(val)
+    if isinstance(val, DetectionResult):
+        if val.specificity is None:
+            return DetectionResult(
+                val.confidence,
+                specificity=_class_specificity(cls),
+                evidence=val.evidence,
+            )
+        return val
+    if val == CandidateStatus.NO:
+        return DetectionResult.no()
+    if val == CandidateStatus.MAYBE:
+        return DetectionResult.match(
+            Confidence.GENERIC_HEADER,
+            specificity=_class_specificity(cls),
+            evidence=("legacy_maybe",),
+        )
+    if val == CandidateStatus.YES:
+        return DetectionResult.match(
+            Confidence.FORMAT_MARKER,
+            specificity=_class_specificity(cls),
+            evidence=("legacy_yes",),
+        )
+    raise TypeError("Unknown candidate result '%s'." % val)
 
 
 def _determine_mixins(path=None, metadata_raw=None):
@@ -170,7 +270,8 @@ def _determine_type(
 
     """
     available_dtypes: list[str] = []
-    dtypes_status: list[CandidateStatus] = []
+    dtypes_results: list[DetectionResult] = []
+    result_by_name: dict[str, DetectionResult] = {}
     reg: dict[str, type] = dict()
     if test_datasets:
         reg.update(**dataset_type_registry)
@@ -178,50 +279,59 @@ def _determine_type(
         reg.update(**dataseries_type_registry)
 
     for k, dtype in reg.items():
-        valid = CandidateStatus.NO
+        valid = DetectionResult.no()
 
         if catch_exception:
             try:
-                valid = is_valid_candidate(dtype.validate_path(path, **kwargs))
+                valid = _candidate_to_detection_result(
+                    dtype.validate_path(path, **kwargs), dtype
+                )
             except Exception as e:
                 log.debug(
                     "Exception raised during validate_path of tested type '%s': %s"
                     % (k, e)
                 )
         else:
-            valid = is_valid_candidate(dtype.validate_path(path, **kwargs))
-        if valid != CandidateStatus.NO:
+            valid = _candidate_to_detection_result(
+                dtype.validate_path(path, **kwargs), dtype
+            )
+        if valid.compatible:
             available_dtypes.append(k)
-            dtypes_status.append(valid)  # will be YES or MAYBE
+            dtypes_results.append(valid)
+            result_by_name[k] = valid
 
     if len(available_dtypes) == 0:
         raise ValueError("Unknown data type.")
     if len(available_dtypes) > 1:
-        # TODO: Rethink how tu use MAYBE/YES information.
-        # below lines not suitable for this.
-        good_matches = [
+        max_confidence = max(r.confidence.value for r in dtypes_results)
+        available_dtypes = [
             k
-            for k, v in zip(available_dtypes, dtypes_status)
-            if v == CandidateStatus.YES
+            for k, r in zip(available_dtypes, dtypes_results)
+            if r.confidence.value == max_confidence
         ]
-        if len(good_matches) >= 1:
-            available_dtypes = (
-                good_matches  # discard all MAYBEs as we have better options
-            )
 
         # reduce candidates by looking at most specific ones.
         inheritancecounters = [Counter(getmro(reg[k])) for k in reg.keys()]
-        mros = [getmro(reg[k]) for k in reg.keys()]
-        lens = [len([m for m in mro if "Mixin" not in m.__name__]) for mro in mros]
-        zp = zip(available_dtypes, lens, dtypes_status)
-        lst = sorted(zp, key=lambda x: x[2].value)
-        lst = sorted(lst, key=lambda x: x[1])
         # try to find candidate that shows up only once across all inheritance trees.
         # => this will be the most specific candidate(s).
         count = reduce(lambda x, y: x + y, inheritancecounters)
         countdict = {k: count[reg[k]] for k in available_dtypes}
         mincount = min(countdict.values())
         available_dtypes = [k for k in available_dtypes if count[reg[k]] == mincount]
+        specificities = {k: result_by_name[k].specificity for k in available_dtypes}
+        max_specificity = max(
+            s.value if isinstance(s, Specificity) else s for s in specificities.values()
+        )
+        available_dtypes = [
+            k
+            for k in available_dtypes
+            if (
+                specificities[k].value
+                if isinstance(specificities[k], Specificity)
+                else specificities[k]
+            )
+            == max_specificity
+        ]
         if len(available_dtypes) > 1:
             # after looking for the most specific candidate(s), do we still have multiple?
             if strict:

--- a/tests/unit/test_discovertypes.py
+++ b/tests/unit/test_discovertypes.py
@@ -1,6 +1,18 @@
+import h5py
+import numpy as np
 import pytest
 
-from scida.discovertypes import CandidateStatus, is_valid_candidate
+from scida import discovertypes
+from scida.customs.arepo.series import ArepoSimulation
+from scida.customs.swift.dataset import SwiftSnapshot
+from scida.discovertypes import (
+    CandidateStatus,
+    Confidence,
+    DetectionResult,
+    Specificity,
+    _determine_type,
+    is_valid_candidate,
+)
 
 
 @pytest.mark.unit
@@ -29,3 +41,102 @@ class TestIsValidCandidate:
         assert is_valid_candidate(CandidateStatus.YES) == CandidateStatus.YES
         assert is_valid_candidate(CandidateStatus.NO) == CandidateStatus.NO
         assert is_valid_candidate(CandidateStatus.MAYBE) == CandidateStatus.MAYBE
+
+
+@pytest.mark.unit
+class TestDetectionResolution:
+    def test_confidence_beats_specificity(self, monkeypatch):
+        class StructurallyCompatibleSpecificDataset:
+            @classmethod
+            def validate_path(cls, path, **kwargs):
+                return DetectionResult.match(
+                    Confidence.GENERIC_HEADER,
+                    specificity=Specificity.SUBFAMILY,
+                    evidence=("generic header",),
+                )
+
+        class FormatIdentifiedFamilyDataset:
+            @classmethod
+            def validate_path(cls, path, **kwargs):
+                return DetectionResult.match(
+                    Confidence.FORMAT_MARKER,
+                    specificity=Specificity.FAMILY,
+                    evidence=("format marker",),
+                )
+
+        monkeypatch.setattr(
+            discovertypes,
+            "dataset_type_registry",
+            {
+                "StructurallyCompatibleSpecificDataset": (
+                    StructurallyCompatibleSpecificDataset
+                ),
+                "FormatIdentifiedFamilyDataset": FormatIdentifiedFamilyDataset,
+            },
+        )
+        monkeypatch.setattr(discovertypes, "dataseries_type_registry", {})
+
+        names, classes = _determine_type("dummy")
+
+        assert names == ["FormatIdentifiedFamilyDataset"]
+        assert classes == [FormatIdentifiedFamilyDataset]
+
+    def test_specificity_breaks_equal_confidence_tie(self, monkeypatch):
+        class FamilyDataset:
+            @classmethod
+            def validate_path(cls, path, **kwargs):
+                return DetectionResult.match(
+                    Confidence.FORMAT_MARKER,
+                    specificity=Specificity.FAMILY,
+                    evidence=("format marker",),
+                )
+
+        class SubfamilyDataset:
+            @classmethod
+            def validate_path(cls, path, **kwargs):
+                return DetectionResult.match(
+                    Confidence.FORMAT_MARKER,
+                    specificity=Specificity.SUBFAMILY,
+                    evidence=("format marker",),
+                )
+
+        monkeypatch.setattr(
+            discovertypes,
+            "dataset_type_registry",
+            {
+                "FamilyDataset": FamilyDataset,
+                "SubfamilyDataset": SubfamilyDataset,
+            },
+        )
+        monkeypatch.setattr(discovertypes, "dataseries_type_registry", {})
+
+        names, classes = _determine_type("dummy")
+
+        assert names == ["SubfamilyDataset"]
+        assert classes == [SubfamilyDataset]
+
+    def test_swift_marker_beats_generic_arepo_series_shape(self, monkeypatch, tmp_path):
+        for i in range(2):
+            with h5py.File(tmp_path / f"flamingo_0042.{i}.hdf5", "w") as f:
+                header = f.create_group("Header")
+                header.attrs["NumFilesPerSnapshot"] = 1
+                header.attrs["NumPart_ThisFile"] = np.zeros(6, dtype="u8")
+                header.attrs["NumPart_Total"] = np.zeros(6, dtype="u8")
+                code = f.create_group("Code")
+                code.attrs["Code"] = np.bytes_(b"SWIFT")
+
+        monkeypatch.setattr(
+            discovertypes,
+            "dataset_type_registry",
+            {"SwiftSnapshot": SwiftSnapshot},
+        )
+        monkeypatch.setattr(
+            discovertypes,
+            "dataseries_type_registry",
+            {"ArepoSimulation": ArepoSimulation},
+        )
+
+        names, classes = _determine_type(tmp_path)
+
+        assert names == ["SwiftSnapshot"]
+        assert classes == [SwiftSnapshot]


### PR DESCRIPTION
## Summary

This refactors dataset type detection so evidence confidence and class specificity are handled separately. Existing `CandidateStatus` validators continue to work, while new `DetectionResult` values allow validators to distinguish generic structural/header matches from format-specific markers.

The FLAMINGO regression was caused by `ArepoSimulation` treating a generic multi-HDF5 `NumFilesPerSnapshot == 1` layout as certain Arepo evidence. That now reports generic-header confidence, while SWIFT markers report format-marker confidence, so FLAMINGO reduced snapshots resolve to `SwiftSnapshot` instead of `ArepoSimulation`.

## Validation

- `uv run pytest tests/unit/test_discovertypes.py -q`
- `SCIDA_TESTDATA_PATH=/newdata/data/public/testdata-astrodask uv run pytest tests/external/swift/test_flamingo.py tests/external/test_type_detection.py -m external -rs`
- `SCIDA_TESTDATA_PATH=/newdata/data/public/testdata-astrodask uv run pytest tests/external -m external -rs`

Full external astrodask run result: `365 passed, 2 failed, 3 skipped, 9 deselected`. The two failures are pre-existing/unrelated issues observed in CI too: `test_load_cachefail[TNG50-4_snapshot]` and the `test_areposimulation_lazy_message[TNG50-4]` timing assertion.