### PR TITLE
Stabilize flaky external tests

### DIFF
--- a/tests/external/test_load.py
+++ b/tests/external/test_load.py
@@ -1,7 +1,5 @@
-import math
 import os
 import pathlib
-from contextlib import contextmanager
 from unittest.mock import MagicMock, patch
 
 import h5py
@@ -113,29 +111,15 @@ def test_load_zarrcutout(testdatapath):
 @require_testdata_path("interface", only=["TNG50-4_snapshot"])
 def test_load_cachefail(cachedir, testdatapath, caplog):
     """Test recovery from failure during cache creation."""
-    import signal
-    import time
-
-    class TimeoutException(Exception):
-        pass
-
-    @contextmanager
-    def time_limit(seconds):
-        def signal_handler(signum, frame):
-            raise TimeoutException("Timed out.")
-        signal.signal(signal.SIGALRM, signal_handler)
-        signal.alarm(seconds)
-        try:
-            yield
-        finally:
-            signal.alarm(0)
-
     loadkwargs = dict(catalog="none")
-    dt = 0.3
-    dt_int = int(math.ceil(dt))
-    with pytest.raises(Exception):
-        with time_limit(dt_int):
-            time.sleep(dt_int - dt)
+
+    def fail_after_partial_cache(cachefp, *args, **kwargs):
+        with h5py.File(cachefp, "w") as f:
+            f.attrs["partial"] = True
+        raise RuntimeError("cache creation interrupted")
+
+    with patch("scida.io._base.create_mergedhdf5file", fail_after_partial_cache):
+        with pytest.raises(RuntimeError, match="cache creation interrupted"):
             load(testdatapath, **loadkwargs)
 
     nfiles = 0

--- a/tests/external/test_series.py
+++ b/tests/external/test_series.py
@@ -78,26 +78,27 @@ def test_delay_obj(testdatapath):
 
 @pytest.mark.external
 @require_testdata_path("areposimulation", only=["TNGvariation_simulation", "TNG50-4"])
-def test_areposimulation_lazy_message(cachedir, testdatapath):
-    tstart = time.process_time()
+def test_areposimulation_lazy_message(cachedir, testdatapath, capsys):
     bs = ArepoSimulation(testdatapath, lazy=True)
-    dt0 = time.process_time() - tstart
+    captured = capsys.readouterr()
     print(bs.datasets[0])
     assert type(bs.datasets[0]).__name__ == "Delay"
-    print(dt0)
-    assert dt0 < 4.0
+    assert "Have not cached this data series. Can take a while." in captured.out
 
 
 @pytest.mark.external
 @require_testdata_path("areposimulation", only=["TNGvariation_simulation", "TNG50-4"])
-def test_areposimulation_lazy(cachedir, testdatapath):
-    tstart = time.process_time()
+def test_areposimulation_lazy(cachedir, testdatapath, capsys):
     bs = ArepoSimulation(testdatapath, lazy=True)
-    dt0 = time.process_time() - tstart
     print(bs.datasets[0])
     assert type(bs.datasets[0]).__name__ == "Delay"
-    print(dt0)
-    assert dt0 < 4.0
+    assert os.path.exists(bs._metadatafile)
+
+    capsys.readouterr()
+    bs = ArepoSimulation(testdatapath, lazy=True)
+    captured = capsys.readouterr()
+    assert type(bs.datasets[0]).__name__ == "Delay"
+    assert "Have not cached this data series. Can take a while." not in captured.out
 
 
 @pytest.mark.external


### PR DESCRIPTION
## Summary
- replace SIGALRM-based cache interruption test with deterministic mocked cache creation failure
- remove fixed CPU-time thresholds from lazy series tests
- assert lazy placeholders, metadata cache creation, and metadata cache reuse instead

## Tests
- uv run pytest tests/external/test_load.py::test_load_cachefail tests/external/test_series.py::test_areposimulation_lazy_message tests/external/test_series.py::test_areposimulation_lazy -m external -rs