### PR TITLE
Reduce chattiness

### DIFF
--- a/src/scida/config.py
+++ b/src/scida/config.py
@@ -7,6 +7,7 @@ from __future__ import annotations
 import importlib.resources
 import os
 import pathlib
+import warnings
 from collections.abc import Callable
 from typing import Any, cast
 
@@ -69,7 +70,7 @@ def get_config(reload: bool = False, update_global=True) -> dict:
         return _conf
     config = get_config_fromfile(path)
     if config.get("copied_default", False):
-        print(
+        warnings.warn(
             "Warning! Using default configuration. Please adjust/replace in '%s'."
             % path
         )

--- a/src/scida/convenience.py
+++ b/src/scida/convenience.py
@@ -208,7 +208,7 @@ def find_path(path, overwrite=False) -> str:
             # dataset on the internet
             savepath = config.get("download_path", None)
             if savepath is None:
-                print(
+                log.info(
                     "Have not specified 'download_path' in config. Using 'cache_path' instead."
                 )
                 savepath = config.get("cache_path")

--- a/src/scida/interfaces/mixins/spatial.py
+++ b/src/scida/interfaces/mixins/spatial.py
@@ -47,13 +47,13 @@ class SpatialCartesian3DMixin(Spatial3DMixin):
             bs = self.header["BoxSize"]
         except KeyError:
             bs = None
-            print("Info: Cannot determine boxsize.")
+            log.exception("Cannot determine boxsize")
         is_cubical = isinstance(bs, np.ndarray) and np.all(bs == bs[0])
         if isinstance(bs, float) or is_cubical:
             self.boxsize[:] = bs
         elif bs is not None:
             # Have not thought about non-cubic cases yet.
-            print("Boxsize:", bs)
+            log.warning("Boxsize %s is non-cubic which is not supported", bs)
             raise NotImplementedError
         common_coord_names = ["Coordinates", "Position", "GroupPos", "SubhaloPos"]
         if "CoordinatesName" not in self.hints:

--- a/src/scida/interfaces/mixins/units.py
+++ b/src/scida/interfaces/mixins/units.py
@@ -507,7 +507,7 @@ class UnitMixin(Mixin):
                     except ValueError as e:
                         if str(e) != "Could not find units.":
                             raise e
-                        print("Hint: Did you pass a unit file? Is it complete?")
+                        log.info("Hint: Did you pass a unit file? Is it complete?")
                         raise ValueError("Could not find units for '%s'" % path)
 
                     # we do not want any pint decorated objects for index fields
@@ -616,13 +616,13 @@ class UnitMixin(Mixin):
         success_states = [UnitState.success, UnitState.success_none]
         count = len([k for k, v in self._unitstates.items() if v not in success_states])
         if count > 0:
-            print("Missing units for %d fields." % count)
+            log.warning("Missing units for %d fields." % count)
             if verbose:
-                print("Fields with missing units:")
+                log.info("Fields with missing units:")
                 for k, v in self._unitstates.items():
                     if v not in success_states:
-                        print("  - %s (%s)" % (k, v.name))
-            print(
+                        log.info("  - %s (%s)" % (k, v.name))
+            log.info(
                 "Re-run with\n\t>>> import logging\n\t>>> logging.getLogger().setLevel(logging.DEBUG)\n"
                 "to learn more."
             )
@@ -759,7 +759,7 @@ def check_missing_units(unit, missing_units, path, logger=log):
         if missing_units == "raise":
             raise ValueError(msg)
         elif missing_units == "warn":
-            logger.info(msg)
+            logger.debug(msg)
         elif missing_units == "ignore":
             pass
         else:

--- a/src/scida/series.py
+++ b/src/scida/series.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 
 import inspect
 import json
+import logging
 import os
 from pathlib import Path
 from typing import Any
@@ -21,6 +22,8 @@ from scida.interface import create_datasetclass_with_mixins
 from scida.io import load_metadata
 from scida.misc import map_interface_args, return_cachefile_path
 from scida.registries import dataseries_type_registry
+
+log = logging.getLogger(__name__)
 
 
 def delay_init(cls):
@@ -152,7 +155,7 @@ class DatasetSeries(object):
         self.datasets = [dec(datasetclass)(p, *a, **kw) for p, a, kw in gen]
 
         if self.metadata is None:
-            print("Have not cached this data series. Can take a while.")
+            log.info("Have not cached this data series. Can take a while.")
             dct = {}
             for i, (path, d) in enumerate(
                 tqdm(zip(self.paths, self.datasets), total=len(self.paths))
@@ -515,7 +518,7 @@ class DatasetSeries(object):
                 try:
                     return json.JSONEncoder.default(self, obj)
                 except TypeError as e:
-                    print("obj failing json encoding:", obj)
+                    log.exception("obj failing json encoding: %s", obj)
                     raise e
 
         self._metadata = dct


### PR DESCRIPTION
At several places in the code, scida complains about not optimal configuration or, most annoying to me, missing units that I am happy to ignore. With these changes, scida never prints something automatically unless it is explicitly asked for it. All outputs are redirected to logging such that the user can pick whether or not they are interested in the additional information.